### PR TITLE
Trigger automatic PDF export after QR generation

### DIFF
--- a/app/invitados/page.tsx
+++ b/app/invitados/page.tsx
@@ -118,6 +118,11 @@ export default function InvitadosPage() {
       })()
       setShowQR(true)
 
+      // Programar la generación automática del PDF una vez que el QR haya sido renderizado
+      setTimeout(() => {
+        void exportToPDF()
+      }, 150)
+
       // Limpiar formulario tras 5s
       setTimeout(() => {
         setFormData({


### PR DESCRIPTION
## Summary
- trigger automatic PDF export shortly after generating the QR code so the invitation downloads without extra interaction
- wait briefly before calling the PDF export routine to ensure the QR has rendered in the DOM

## Testing
- npm run lint *(fails: command became interactive and required manual selection)*

------
https://chatgpt.com/codex/tasks/task_e_68d58b28cae8832cadabfb533a3ad762